### PR TITLE
fix(telecomms): Fixes another null_ref related to broadcast()

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -117,8 +117,10 @@
 				message = stars(message)
 			else // Used for compression
 				message = RadioChat(null, message, 80, 1+(hard_to_hear/10))
-
-	var/speaker_name = speaker.name
+	
+	var/speaker_name = "Unknown"
+	if(speaker)
+		speaker_name = speaker.name
 
 	if(vname)
 		speaker_name = vname


### PR DESCRIPTION
Closes #13
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/TheDaedalusCrew/Daedalus-of-Freedom/pull/14?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/TheDaedalusCrew/Daedalus-of-Freedom/pull/14'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>