### PR TITLE
Added Check Dirtyness verb

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -36,3 +36,14 @@
 
 		if(!client && !mind && species)
 			species.handle_npc(src)
+
+/mob/living/carbon/verb/check_dirtyness()
+	set name = "Check Dirtyness"
+	set category = "IC"
+
+	if(src.germ_level > 150)
+		to_chat(src, "<span class='notice'>You notice that you are a bit dirty.</span>")
+	else if(src.germ_level > 299)
+		to_chat(src, "<span class='warning'>You feel like you should really take a shower.</span>")
+	else
+		to_chat(src, "<span class='notice'>You feel very clean.</span>")


### PR DESCRIPTION
Added Check Dirtyness verb to allow players to check if they are too dirty.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
