### PR TITLE
Make the game try to connect to MySQL for longer.

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -640,7 +640,7 @@ var/world_topic_spam_protect_time = world.timeofday
 #undef WORLD_SETUP_LOG
 #undef WORLD_LOG_START
 
-#define FAILED_DB_CONNECTION_CUTOFF 5
+#define FAILED_DB_CONNECTION_CUTOFF 999 //The database is used for some important stuff, just keep trying okay? --Alice
 var/failed_db_connections = 0
 var/failed_old_db_connections = 0
 


### PR DESCRIPTION
This sets the MySQL reconnection limit to 999, hopefully this will prevent those cases where users can't pick their favourite job because the game doesn't remember them (due to the database not being setup).