### PR TITLE
Fix compatibility of IRC bot file with HTTP server

### DIFF
--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -4,7 +4,7 @@
 /proc/export2irc(params)
 	if(config.use_irc_bot && config.irc_bot_host)
 		spawn(-1) // spawn here prevents hanging in the case that the bot isn't reachable
-			world.Export("http://[config.irc_bot_host]:45678?[list2params(params)]")
+			world.Export("http://[config.irc_bot_host]:45678/?[list2params(params)]")
 
 /proc/runtimes2irc(runtimes, revision)
 	export2irc(list(pwd=config.comms_password, type="runtime", runtimes=runtimes, revision=revision))


### PR DESCRIPTION
The normal script for the IRC bot doesn't provide a path which breaks compatibility with most HTTP servers.

This commit provides the base path of /

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->